### PR TITLE
correction exo DEDUPE

### DIFF
--- a/Double.js
+++ b/Double.js
@@ -1,18 +1,10 @@
 const duplicate = ['foobar', 'test', 'john', 'doe','test',  'foobar', 'test', 'test', 'test',  'foobar', 'test',  'foobar', 'test', 'fin']
-var tableau =[];
-for (var i = 0 ; i<= duplicate.length; i++){
-    tableau[i] = duplicate[i];
-};
-console.log(tableau);
-var max = tableau.length;
+const tableau = [...duplicate] // spread operator pour faire une véritable copie d'un tableau
 
-for(max; max >= 1; max--){
+for(let max = tableau.length; max >= 1; max--){
     tableau.sort();
     if(tableau[max] === tableau[max - 1]){
-        var elementSupp = tableau.splice(max, 1);
-        console.log(tableau);
+      tableau.splice(max, 1);
     }
 }
-
-console.log('le tableau duplucate : ' +duplicate);
-alert('Voici le  tableau sans doublon : ' + tableau);
+console.log('le tableau dedupe : ' +tableau);


### PR DESCRIPTION
c'était presque bon:

la copie du tableau dans une boucle for avec un index de trop créeait une valeur "undefined"
il suffit d'utiliser le spread operator pour copier un tableau.

Essaye de faire une seconde version en utilisant la fonction `includes()` plutôt que `sort()`.
Quand on corrigera on fera un *test de performance* avec tes versions et 2 autres versions supplémentaires.